### PR TITLE
builder: publish prefix default to dev

### DIFF
--- a/ssm_dox_builder/_cli/commands/_publish.py
+++ b/ssm_dox_builder/_cli/commands/_publish.py
@@ -6,7 +6,6 @@ from typing import Optional
 import boto3
 import click
 
-from ... import __version__
 from ...constants import SHARED_SSM_DOCS
 from ...finder import Finder
 from .utils import click_directory
@@ -17,9 +16,7 @@ LOGGER = logging.getLogger(__name__)
 @click.command("publish", short_help="publish documents")
 @click.argument("bucket", default="shared-ssm-dox-dev", required=True)
 @click.argument("documents_path", callback=click_directory, default=SHARED_SSM_DOCS)
-@click.option(
-    "-p", "--prefix", default=__version__, help="prefix to append to S3 Object key"
-)
+@click.option("-p", "--prefix", default="dev", help="prefix to append to S3 Object key")
 @click.option("--profile", default=None, help="AWS profile name")
 @click.option("--region", default=None, help="AWS region where the bucket is located")
 def publish(


### PR DESCRIPTION
# Summary

Change `publish --prefix` default value to `dev`.

# Why This Is Needed

Prevents accidentally overwriting versioned releases.

# What Changed

## Changed

- `publish --prefix` now defaults to `dev` instead of the current version