### PR TITLE
builder: add `!LinuxOnly` & `!WindowsOnly` YAML tags for precondition

### DIFF
--- a/dox/README.md
+++ b/dox/README.md
@@ -8,6 +8,8 @@ This file uses YAML tags specific to this tool to build SSM Documents by includi
 
 ## Custom YAML Tags
 
-| Tag              | Description                                                          | Usage                      |
-|------------------|----------------------------------------------------------------------|----------------------------|
-| `!IncludeScript` | include the contents of a file, splitting each line into a list item | `!IncludeScript ./file.sh` |
+| Tag              | Description                                                          | Usage                        |
+|------------------|----------------------------------------------------------------------|------------------------------|
+| `!IncludeScript` | include the contents of a file, splitting each line into a list item | `!IncludeScript ./file.sh`   |
+| `!LinuxOnly`     | main step precondition that limits it to only run on Linux systems   | `precondition: !LinuxOnly`   |
+| `!WindowsOnly`   | main step precondition that limits it to only run on Windows systems | `precondition: !WindowsOnly` |

--- a/dox/configuration/AWSTimeSync/template.yml
+++ b/dox/configuration/AWSTimeSync/template.yml
@@ -18,18 +18,12 @@ parameters:
 mainSteps:
   - action: aws:runShellScript
     name: LinuxInstall
-    precondition:
-      StringEquals:
-        - platformType
-        - Linux
+    precondition: !LinuxOnly
     inputs:
       runCommand: !IncludeScript install.sh
   - action: aws:runPowerShellScript
     name: WindowsInstall
-    precondition:
-      StringEquals:
-        - platformType
-        - Windows
+    precondition: !WindowsOnly
     inputs:
       runCommand: !IncludeScript install.ps1
       timeoutSeconds: 7200

--- a/dox/configuration/InstallCodeDeploy/template.yml
+++ b/dox/configuration/InstallCodeDeploy/template.yml
@@ -4,17 +4,11 @@ description: Install Code Deploy agent on supported OSes.
 mainSteps:
   - action: aws:runShellScript
     name: LinuxInstall
-    precondition:
-      StringEquals:
-        - platformType
-        - Linux
+    precondition: !LinuxOnly
     inputs:
       runCommand: !IncludeScript ./install.sh
   - action: aws:runPowerShellScript
     name: WindowsInstall
-    precondition:
-      StringEquals:
-        - platformType
-        - Windows
+    precondition: !WindowsOnly
     inputs:
       runCommand: !IncludeScript ./install.ps1

--- a/dox/configuration/InstallPackages/template.yml
+++ b/dox/configuration/InstallPackages/template.yml
@@ -10,9 +10,6 @@ parameters:
 mainSteps:
   - action: aws:runShellScript
     name: LinuxInstall
-    precondition:
-      StringEquals:
-        - platformType
-        - Linux
+    precondition: !LinuxOnly
     inputs:
       runCommand: !IncludeScript ./install_packages.sh

--- a/dox/diagnostics/EC2CpuScan/template.yml
+++ b/dox/diagnostics/EC2CpuScan/template.yml
@@ -11,17 +11,11 @@ parameters:
 mainSteps:
   - action: aws:runShellScript
     name: LinuxCpuScan
-    precondition:
-      StringEquals:
-        - platformType
-        - Linux
+    precondition: !LinuxOnly
     inputs:
       runCommand: !IncludeScript ./cpu_scan.sh
   - action: aws:runPowerShellScript
     name: WindowsCpuScan
-    precondition:
-      StringEquals:
-        - platformType
-        - Windows
+    precondition: !WindowsOnly
     inputs:
       runCommand: !IncludeScript ./cpu_scan.ps1

--- a/ssm_dox_builder/dox.py
+++ b/ssm_dox_builder/dox.py
@@ -37,8 +37,20 @@ class DoxLoader(yaml.SafeLoader):
         with open(script, "r") as f:
             return [line.rstrip() for line in f.readlines()]
 
+    # pylint: disable=no-self-use,unused-argument
+    def construct_linux_only(self, node: yaml.Node) -> Any:
+        """Handle !LinuxOnly."""
+        return {"StringEquals": ["platformType", "Linux"]}
+
+    # pylint: disable=no-self-use,unused-argument
+    def construct_windows_only(self, node: yaml.Node) -> Any:
+        """Handle !WindowsOnly."""
+        return {"StringEquals": ["platformType", "Windows"]}
+
 
 DoxLoader.add_constructor("!IncludeScript", DoxLoader.construct_include_script)  # type: ignore
+DoxLoader.add_constructor("!LinuxOnly", DoxLoader.construct_linux_only)  # type: ignore
+DoxLoader.add_constructor("!WindowsOnly", DoxLoader.construct_windows_only)  # type: ignore
 
 
 class Dox(NestedFileMixin):


### PR DESCRIPTION
# Summary

YAML tags for `mainStep.precondition` shorthand.

# What Changed

## Added

- added `!LinuxOnly` YAML tag that can be provided to `mainStep.precondition` to only run the step on Linux systems
- added `!WindowsOnly` YAML tag that can be provided to `mainStep.precondition` to only run the step on Windows systems