### PR TITLE
builder: document schemaVersion default value of 2.2

### DIFF
--- a/ssm_dox_builder/models/document.py
+++ b/ssm_dox_builder/models/document.py
@@ -13,7 +13,7 @@ from .parameter import SsmDocumentParameterDataModel
 class SsmDocumentDataModel(BaseModel):
     """AWS SSM Document data model."""
 
-    schemaVersion: str
+    schemaVersion: str = "2.2"
     description: str
     parameters: Optional[Dict[str, SsmDocumentParameterDataModel]] = None
     mainSteps: List[AnyMainStep]


### PR DESCRIPTION
# Summary

Use the latest schema version as the default value.

# What Changed

## Changed

- document `schemaVersion` has a default value of 2.2