### PR TITLE
builder: fix parameter default value type so str is not converted

### DIFF
--- a/dox/diagnostics/EC2CpuScan/template.yml
+++ b/dox/diagnostics/EC2CpuScan/template.yml
@@ -5,7 +5,7 @@ parameters:
   ResultCount:
     type: String
     description: The number of results to return for top processes.
-    default: 5
+    default: "5"
     allowedPattern: "^[0-9]{1,2}$"
 
 mainSteps:

--- a/shared_ssm_docs/configuration/AWSTimeSync.json
+++ b/shared_ssm_docs/configuration/AWSTimeSync.json
@@ -9,7 +9,7 @@
             "type": "String"
         },
         "WindowsConfigureIfDomainMember": {
-            "default": false,
+            "default": "False",
             "description": "(Windows only) Configure even if Windows instance is joined to a domain? (True|False)",
             "type": "String"
         }

--- a/shared_ssm_docs/configuration/InstallPackages.json
+++ b/shared_ssm_docs/configuration/InstallPackages.json
@@ -3,7 +3,7 @@
     "description": "Install a list of packages on an OS.",
     "parameters": {
         "Packages": {
-            "default": {},
+            "default": "",
             "description": "Space separated list of packages to be installed/",
             "type": "String"
         }

--- a/shared_ssm_docs/diagnostics/EC2CpuScan.json
+++ b/shared_ssm_docs/diagnostics/EC2CpuScan.json
@@ -4,7 +4,7 @@
     "parameters": {
         "ResultCount": {
             "allowedPattern": "^[0-9]{1,2}$",
-            "default": 5,
+            "default": "5",
             "description": "The number of results to return for top processes.",
             "type": "String"
         }

--- a/ssm_dox_builder/models/parameter.py
+++ b/ssm_dox_builder/models/parameter.py
@@ -13,13 +13,13 @@ class SsmDocumentParameterDataModel(BaseModel):
     allowedValues: Optional[List[str]] = None
     default: Optional[
         Union[
+            str,
             bool,
             Dict[str, str],
             Dict[str, List[str]],
             int,
             List[Dict[str, str]],
             List[str],
-            str,
         ]
     ] = None
     description: Optional[str] = None


### PR DESCRIPTION
# Summary

The type annotation of the parameter model caused some values to be incorrectly converted to non-string types.

# What Changed

## Fixed

- fixed an issue causing parameter default value to never be str when using a str containing an int or bool in the template
- `Ec2CpuScan.parameters.ResultCount` now correctly defaults to `"5"`
- `InstallPackages.parameters.Packages` now correctly defaults to `""`
